### PR TITLE
CI: fix grpcio version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,14 @@ jobs:
       python: "3.6"
       install:
         - pip3 install -e python
-        - ./_tools/install-lookout-latest.sh
       script:
+        - ./_tools/install-lookout-latest.sh
         - (python3 language-analyzer.py |& tee -a ../py-analyzer.log)&
         - ../lookout_sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2021"
       after_failure:
+        - echo "test"
         - cat ../py-analyzer.log
+        - cat ../lookout-install.log
 
     - name: "Golang: example integration tests"
       stage: test
@@ -41,13 +43,14 @@ jobs:
       install:
         - go version
         - go get .
-        - ./_tools/install-lookout-latest.sh
       script:
+        - ./_tools/install-lookout-latest.sh
         - (go run language-analyzer.go |& tee -a ../go-analyzer.log)&
         - sleep 1s
         - ../lookout_sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2020"
       after_failure:
         - cat ../go-analyzer.log
+        - cat ../lookout-install.log
 
     - name: "Generated code"
       stage: test

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ check-protoc:
 protogen: check-protoc
 		$(GOCMD) get github.com/gogo/protobuf/protoc-gen-gogofaster
 		./_tools/protogen_golang.sh
-		pip3 install grpcio_tools
+		pip3 install grpcio_tools==1.13.0
 		./_tools/protogen_python.sh

--- a/_tools/install-lookout-latest.sh
+++ b/_tools/install-lookout-latest.sh
@@ -4,23 +4,34 @@
 # Depends on GNU grep
 set -x
 
-#TODO(bzz): check local cached version
+#TODO(bzz): check for local cached version first
 
-curl -s --connect-timeout 5 \
+OS="$(uname | tr '[:upper:]' '[:lower:]')"
+
+oIFS=$IFS IFS=' '
+curl -v ${GITHUB_TOKEN:+'-H' "Authorization: token $GITHUB_TOKEN"} \
+    --connect-timeout 5 \
     --max-time 10 \
     --retry 5 \
     --retry-delay 0 \
     --retry-max-time 40\
     "https://api.github.com/repos/src-d/lookout/releases/latest" \
-  |& tee -a ../lookout-install.log \
+  | tee -a ../lookout-install.log \
   | grep -oP '"browser_download_url": "\K(.*)(?=")' \
-  | grep linux \
+  | grep "${OS}" \
   | wget -qi -
 
-if [[ "${PIPESTATUS[0]}" -ne 0 || "${PIPESTATUS[1]}" -ne 0 || "${PIPESTATUS[2]}" -ne 0 || "${PIPESTATUS[4]}" -ne 0 ]]; then
+if [[ "${PIPESTATUS[0]}" -ne 0 || \
+      "${PIPESTATUS[1]}" -ne 0 || \
+      "${PIPESTATUS[2]}" -ne 0 || \
+      "${PIPESTATUS[3]}" -ne 0 || \
+      "${PIPESTATUS[4]}" -ne 0 ]];
+then
   echo "Unable download latest lookout SDK release" >&2
   exit 2
 fi
+IFS=$oIFS; unset -v oIFS
+# http://mywiki.wooledge.org/BashFAQ/050#I_only_want_to_pass_options_if_the_runtime_data_needs_them
 
 if ! tar -xvzf lookout-sdk_*.tar.gz ; then
   echo "Unable to extract lookout release archive" >&2

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,7 +23,7 @@ setup(
         download_url="https://github.com/src-d/lookout-sdk",
         packages=find_packages(),
         keywords=["analyzer", "code-reivew"],
-        install_requires=["grpcio>=1.13.0", "protobuf>=3.6.0", "bblfsh"],
+        install_requires=["grpcio==1.13.0", "protobuf==3.6.1", "bblfsh"],
         package_data={"": ["../LICENSE", "../MAINTAINERS", README]},
         classifiers=[
             "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Following https://github.com/bblfsh/client-python/pull/110

This resolves CI failures from [master](https://travis-ci.org/src-d/lookout-sdk/jobs/429940471) and #10 ([log](https://travis-ci.org/src-d/lookout-sdk/jobs/429940471))

 - fix grpcio version
 - make sdk binary installation more robust