### PR TITLE
Use current dir for tool downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 
 python/build
 python/dist
+
+protoc

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ python/build
 python/dist
 
 protoc
+
+py-analyzer.log
+go-analyzer.log
+lookout-install.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ jobs:
         - pip3 install -e python
       script:
         - ./_tools/install-lookout-latest.sh
-        - (python3 language-analyzer.py |& tee -a ../py-analyzer.log)&
-        - ../lookout_sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2021"
+        - (python3 language-analyzer.py |& tee -a ./py-analyzer.log)&
+        - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2021"
       after_failure:
         - echo "test"
-        - cat ../py-analyzer.log
-        - cat ../lookout-install.log
+        - cat ./py-analyzer.log
+        - cat ./lookout-install.log
 
     - name: "Golang: example integration tests"
       stage: test
@@ -45,12 +45,12 @@ jobs:
         - go get .
       script:
         - ./_tools/install-lookout-latest.sh
-        - (go run language-analyzer.go |& tee -a ../go-analyzer.log)&
+        - (go run language-analyzer.go |& tee -a ./go-analyzer.log)&
         - sleep 1s
-        - ../lookout_sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2020"
+        - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2020"
       after_failure:
-        - cat ../go-analyzer.log
-        - cat ../lookout-install.log
+        - cat ./go-analyzer.log
+        - cat ./lookout-install.log
 
     - name: "Generated code"
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,5 +77,5 @@ jobs:
 
 cache:
   directories:
-    - $HOME/protoc
+    - protoc
     - $HOME/.cache/pip/wheels

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ check-protoc:
 protogen: check-protoc
 		$(GOCMD) get github.com/gogo/protobuf/protoc-gen-gogofaster
 		./_tools/protogen_golang.sh
-		pip3 install grpcio_tools==1.13.0
+		pip3 install --user grpcio_tools==1.13.0
 		./_tools/protogen_python.sh

--- a/_tools/install-lookout-latest.sh
+++ b/_tools/install-lookout-latest.sh
@@ -16,7 +16,7 @@ curl -v ${GITHUB_TOKEN:+'-H' "Authorization: token $GITHUB_TOKEN"} \
     --retry-delay 0 \
     --retry-max-time 40\
     "https://api.github.com/repos/src-d/lookout/releases/latest" \
-  | tee -a ../lookout-install.log \
+  | tee -a ./lookout-install.log \
   | grep -oP '"browser_download_url": "\K(.*)(?=")' \
   | grep "${OS}" \
   | wget -qi -
@@ -38,10 +38,7 @@ if ! tar -xvzf lookout-sdk_*.tar.gz ; then
   exit 2
 fi
 
-# using lookout_sdk binary name, to workaround current dir name
-# also beeing lookout-sdk on Travis, that is not customizable
-# https://github.com/travis-ci/travis-ci/issues/9993
-if ! mv lookout-sdk_*/lookout-sdk ../lookout_sdk ; then
+if ! mv lookout-sdk_*/lookout-sdk ./lookout-sdk ; then
   echo "Unable to move lookout-sdk binary file" >&2
   exit 2
 fi

--- a/_tools/install-protoc-maybe.sh
+++ b/_tools/install-protoc-maybe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Checks Protobuff compiler version. 
+# Checks Protobuf compiler version.
 # If absent, installs one in protoc_dir from GH release.
 
 PROTOC_VER="3.6.0"
@@ -11,7 +11,7 @@ else
 	protoc_os="linux"
 fi
 
-protoc_dir="../protoc"
+protoc_dir="./protoc"
 
 cur_ver="$("$protoc_dir/bin/protoc" --version | grep -o '[^ ]*$')"
 if [[ "$cur_ver" == "$PROTOC_VER" ]]; then

--- a/_tools/protogen_golang.sh
+++ b/_tools/protogen_golang.sh
@@ -3,13 +3,13 @@
 # Generates Protobuf + gRCP for Golang
 # Assumes 'protoc' and 'protoc-gen-gogofaster' binaries are installed
 
-PROTOC="../protoc/bin/protoc"
+PROTOC="./protoc/bin/protoc"
 sdk="lookout/sdk"
 src="proto"
 dst="golang"
 
 
-[[ -f "../protoc/bin/protoc" ]] >/dev/null 2>&1 || { echo "Protobuf compiler is required but not found in ${PROTOC}" >&2; exit 1; }
+[[ -f $PROTOC ]] >/dev/null 2>&1 || { echo "Protobuf compiler is required but not found in ${PROTOC}" >&2; exit 1; }
 
 if ! mkdir -p "${dst}" ; then
     echo "Failed to create ${dst}"


### PR DESCRIPTION
Doing `make protogen` I faced some problems, and it took me a while to realize the problem because the bash scripts are downloading things in the project's parent dir.

In my opinion we should either use the current dir, or tmp. In this PR:
- downloads are made on the current dir, not the parent.
- `make protogen` uses `pip3 --user` to make it more user-friendly.