### PR TITLE
Add a linter for python pep8 style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,15 @@ stages:
 
 jobs:
   include:
+    - name: "Linters"
+      stage: test
+      language: python
+      python: "3.6"
+      install:
+        - pip3 install --upgrade pycodestyle
+      script:
+        - pycodestyle --max-line-length=99 --exclude='./python/lookout/sdk' .
+
     - name: "Python: example integration tests"
       stage: test
       language: python

--- a/language-analyzer.py
+++ b/language-analyzer.py
@@ -18,7 +18,8 @@ from bblfsh import filter as filter_uast
 port_to_listen = 2021
 data_srv_addr = "localhost:10301"
 version = "alpha"
-grpc_max_msg_size = 100 * 1024 * 1024 #100mb
+grpc_max_msg_size = 100 * 1024 * 1024  # 100mb
+
 
 class Analyzer(service_analyzer_pb2_grpc.AnalyzerServicer):
     def NotifyReviewEvent(self, request, context):
@@ -52,6 +53,7 @@ class Analyzer(service_analyzer_pb2_grpc.AnalyzerServicer):
     def NotifyPushEvent(self, request, context):
         pass
 
+
 def serve():
     server = grpc.server(thread_pool=ThreadPoolExecutor(max_workers=10))
     service_analyzer_pb2_grpc.add_AnalyzerServicer_to_server(Analyzer(), server)
@@ -65,9 +67,11 @@ def serve():
     except KeyboardInterrupt:
         server.stop(0)
 
+
 def main():
     print("starting gRPC Analyzer server at port {}".format(port_to_listen))
     serve()
+
 
 if __name__ == "__main__":
     main()

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,9 +11,9 @@ with io.open(os.path.join(here, README), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
 setup(
-        name = "lookout_sdk",
-        version = VERSION,
-        description = description,
+        name="lookout_sdk",
+        version=VERSION,
+        description=description,
         license="Apache 2.0",
         author="source{d}",
         long_description=long_description,


### PR DESCRIPTION
Includes the commit from #19.

The linter ignores the autogenerated code, and sets the line length to 99, as defined in [our guide](https://github.com/src-d/guide/blob/master/engineering/conventions-python.md).