### PR TITLE
Remove git clone depth in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_install:
 
 go_import_path: gopkg.in/src-d/lookout-sdk.v0
 
+git:
+  depth: false
+
 stages:
   - name: test
   - name: release


### PR DESCRIPTION
Tests are failing in master because we use this repo for the tests, and the default clone depth of 50 finally left out the commits we use.

Context:
https://travis-ci.org/src-d/lookout-sdk/jobs/445009718#L747
https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth