### PR TITLE
allow file schema for repositories

### DIFF
--- a/pb/event.go
+++ b/pb/event.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"strings"
 )
@@ -124,6 +125,7 @@ func ParseRepositoryInfo(input string) (*RepositoryInfo, error) {
 		return &RepositoryInfo{
 			CloneURL: input,
 			FullName: u.Path,
+			Name:     filepath.Base(u.Path),
 		}, nil
 	}
 

--- a/pb/event.go
+++ b/pb/event.go
@@ -120,6 +120,13 @@ func ParseRepositoryInfo(input string) (*RepositoryInfo, error) {
 		return ParseRepositoryInfo("https://" + input)
 	}
 
+	if u.Scheme == "file" {
+		return &RepositoryInfo{
+			CloneURL: input,
+			FullName: u.Path,
+		}, nil
+	}
+
 	if u.Scheme != "https" {
 		return nil, fmt.Errorf("only https urls are supported")
 	}

--- a/pb/event_test.go
+++ b/pb/event_test.go
@@ -73,6 +73,13 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "bar",
 			},
 		},
+		{
+			Input: "file:///some/path/to/repo",
+			Expected: RepositoryInfo{
+				CloneURL: "file:///some/path/to/repo",
+				FullName: "/some/path/to/repo",
+			},
+		},
 	}
 
 	errorCases := []struct {

--- a/pb/event_test.go
+++ b/pb/event_test.go
@@ -78,6 +78,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Expected: RepositoryInfo{
 				CloneURL: "file:///some/path/to/repo",
 				FullName: "/some/path/to/repo",
+				Name:     "repo",
 			},
 		},
 	}


### PR DESCRIPTION
we need to support file schema too.

we use it in lookout-sdk binary.