### PR TITLE
actually test analyzers in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
+dist: xenial
+sudo: required
+
 language: generic
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-6
-    - g++-6
-
-before_install:
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
 
 go_import_path: gopkg.in/src-d/lookout-sdk.v0
 
@@ -24,60 +15,70 @@ stages:
 
 jobs:
   include:
-    - name: "Linters"
+    - name: 'Linters'
       stage: test
       language: python
-      python: "3.6"
+      python: '3.6'
       install:
         - pip3 install --upgrade pycodestyle
       script:
         - pycodestyle --max-line-length=99 --exclude='./python/lookout/sdk' .
 
-    - name: "Python: example integration tests"
+    - name: 'Python: example integration tests'
       stage: test
       language: python
-      python: "3.6"
+      python: '3.6'
       install:
+        - ./_tools/ci-run-bblfsh.sh
         - pip3 install -e python
       script:
         - ./_tools/install-lookout-latest.sh
         - (python3 language-analyzer.py |& tee -a ./py-analyzer.log)&
+        - sleep 5s
         - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2021"
+        - grep -v "error" ./py-analyzer.log > /dev/null
       after_failure:
-        - echo "test"
         - cat ./py-analyzer.log
-        - cat ./lookout-install.log
 
-    - name: "Golang: example integration tests"
+    - name: 'Golang: example integration tests'
       stage: test
       language: go
-      go: "1.10"
+      go: '1.10'
       install:
         - go version
         - go get .
       script:
+        - ./_tools/ci-run-bblfsh.sh
         - ./_tools/install-lookout-latest.sh
         - (go run language-analyzer.go |& tee -a ./go-analyzer.log)&
-        - sleep 1s
+        - sleep 5s
         - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2020"
+        - grep -v "error" ./go-analyzer.log > /dev/null
       after_failure:
         - cat ./go-analyzer.log
-        - cat ./lookout-install.log
 
-    - name: "Generated code"
+    - name: 'Golang test'
       stage: test
       language: go
-      go: "1.10"
+      go: '1.10'
+      script:
+        - make dependencies
+        - make test
+
+    - name: 'Generated code'
+      stage: test
+      language: go
+      go: '1.10'
       env:
         - PYENV_VERSION="3.6"
       script:
         - make protogen
         - make no-changes-in-commit
 
-    - name: "Python: release a library"
+    - name: 'Python: release a library'
       stage: release
       language: python
-      python: "3.6"
+      python: '3.6'
       before_script:
         - pip3 install twine
         - cd python
@@ -86,8 +87,12 @@ jobs:
         - twine upload dist/*py3-none-any* -u $PYPI_LOGIN -p $PYPI_PASS
       skip_cleanup: true
 
+before_cache:
+  # make bblfsh images readable
+  - sudo chmod -R 777 $HOME/bblfshd/images
 
 cache:
   directories:
     - protoc
     - $HOME/.cache/pip/wheels
+    - $HOME/bblfshd/images

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,10 @@ jobs:
         - pip3 install -e python
       script:
         - ./_tools/install-lookout-latest.sh
-        - (python3 language-analyzer.py |& tee -a ./py-analyzer.log)&
+        - (python3 -u language-analyzer.py |& tee -a ./py-analyzer.log)&
         - sleep 5s
         - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2021"
         - grep -v "error" ./py-analyzer.log > /dev/null
-      after_failure:
-        - cat ./py-analyzer.log
 
     - name: 'Golang: example integration tests'
       stage: test
@@ -54,8 +52,6 @@ jobs:
         - sleep 5s
         - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2020"
         - grep -v "error" ./go-analyzer.log > /dev/null
-      after_failure:
-        - cat ./go-analyzer.log
 
     - name: 'Golang test'
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,11 @@ jobs:
         - pip3 install -e python
       script:
         - ./_tools/install-lookout-latest.sh
-        - (python3 -u language-analyzer.py |& tee -a ./py-analyzer.log)&
+        - (python3 -u language-analyzer.py |& tee ./py-analyzer.log)&
         - sleep 5s
-        - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2021"
-        - grep -v "error" ./py-analyzer.log > /dev/null
+        - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2021" |& tee ./sdk.log
+        - grep -v -i "error" ./py-analyzer.log > /dev/null
+        - grep -v -i "error" ./sdk.log > /dev/null
 
     - name: 'Golang: example integration tests'
       stage: test
@@ -48,10 +49,11 @@ jobs:
       script:
         - ./_tools/ci-run-bblfsh.sh
         - ./_tools/install-lookout-latest.sh
-        - (go run language-analyzer.go |& tee -a ./go-analyzer.log)&
+        - (go run language-analyzer.go |& tee ./go-analyzer.log)&
         - sleep 5s
-        - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2020"
-        - grep -v "error" ./go-analyzer.log > /dev/null
+        - ./lookout-sdk review --log-level=debug --from 0a9d1d159d2b0064c32df8d2287b174a91390b1a --to HEAD "ipv4://localhost:2020" |& tee ./sdk.log
+        - grep -v -i "error" ./go-analyzer.log > /dev/null
+        - grep -v -i "error" ./sdk.log > /dev/null
 
     - name: 'Golang test'
       stage: test

--- a/_tools/ci-run-bblfsh.sh
+++ b/_tools/ci-run-bblfsh.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Runs bblfsh server in CI
+
+set -e
+
+docker run -d --name bblfshd --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd:v2.9.2
+docker exec -it bblfshd bblfshctl driver install --force go bblfsh/go-driver:v2.4.0

--- a/language-analyzer.go
+++ b/language-analyzer.go
@@ -60,6 +60,10 @@ func (*analyzer) NotifyReviewEvent(ctx context.Context, review *pb.ReviewEvent) 
 			continue
 		}
 
+		if change.Head == nil {
+			continue
+		}
+
 		log.Infof("analyzing '%s' in %s", change.Head.Path, change.Head.Language)
 
 		//TODO: put your analysis here!


### PR DESCRIPTION
Fix: #31

- make ci faster
- fix lack of output for python analyzer
- add checks for error
- add unit tests run
- add bblfsh (both analyzers depend on it)
- fix for golang example analyzer (panic)