### PR TITLE
Clear __init__

### DIFF
--- a/python/lookout/sdk/__init__.py
+++ b/python/lookout/sdk/__init__.py
@@ -1,3 +1,0 @@
-# re-export using pythonic names
-from lookout.sdk.service_analyzer_pb2_grpc import \
-    AnalyzerServicer, add_AnalyzerServicer_to_server as add_analyzer_to_server


### PR DESCRIPTION
GRPC is such a huge pile of crap that we should not touch it by
doing a mere package import.

Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>