### PR TITLE
Remove grpc imports from init and add pb package

### DIFF
--- a/language-analyzer.py
+++ b/language-analyzer.py
@@ -10,11 +10,12 @@ from concurrent.futures import ThreadPoolExecutor
 import time
 import grpc
 from lookout.sdk import pb
+from lookout.sdk.grpc import to_grpc_address, create_channel
 
 from bblfsh import filter as filter_uast
 
 port_to_listen = 2021
-data_srv_addr = pb.to_grpc_address("ipv4://localhost:10301")
+data_srv_addr = to_grpc_address("ipv4://localhost:10301")
 version = "alpha"
 
 
@@ -23,7 +24,7 @@ class Analyzer(pb.AnalyzerServicer):
         print("got review request {}".format(request))
 
         # client connection to DataServe
-        channel = pb.create_channel(data_srv_addr)
+        channel = create_channel(data_srv_addr)
         stub = pb.DataStub(channel)
         changes = stub.GetChanges(
             pb.ChangesRequest(

--- a/language-analyzer.py
+++ b/language-analyzer.py
@@ -9,29 +9,24 @@ from concurrent.futures import ThreadPoolExecutor
 
 import time
 import grpc
-
-from lookout.sdk import AnalyzerServicer, add_analyzer_to_server
-from lookout.sdk import service_analyzer_pb2
-from lookout.sdk import service_data_pb2_grpc
-from lookout.sdk import service_data_pb2
-from lookout.sdk.grpc import to_grpc_address, create_channel
+from lookout.sdk import pb
 
 from bblfsh import filter as filter_uast
 
 port_to_listen = 2021
-data_srv_addr = to_grpc_address("ipv4://localhost:10301")
+data_srv_addr = pb.to_grpc_address("ipv4://localhost:10301")
 version = "alpha"
 
 
-class Analyzer(AnalyzerServicer):
+class Analyzer(pb.AnalyzerServicer):
     def NotifyReviewEvent(self, request, context):
         print("got review request {}".format(request))
 
         # client connection to DataServe
-        channel = create_channel(data_srv_addr)
-        stub = service_data_pb2_grpc.DataStub(channel)
+        channel = pb.create_channel(data_srv_addr)
+        stub = pb.DataStub(channel)
         changes = stub.GetChanges(
-            service_data_pb2.ChangesRequest(
+            pb.ChangesRequest(
                 head=request.commit_revision.head,
                 base=request.commit_revision.base,
                 want_contents=False,
@@ -47,11 +42,11 @@ class Analyzer(AnalyzerServicer):
                 change.head.path, change.head.language))
             fns = list(filter_uast(change.head.uast, "//*[@roleFunction]"))
             comments.append(
-                service_analyzer_pb2.Comment(
+                pb.Comment(
                     file=change.head.path,
                     line=0,
                     text="language: {}, functions: {}".format(change.head.language, len(fns))))
-        return service_analyzer_pb2.EventResponse(analyzer_version=version, comments=comments)
+        return pb.EventResponse(analyzer_version=version, comments=comments)
 
     def NotifyPushEvent(self, request, context):
         pass
@@ -59,7 +54,7 @@ class Analyzer(AnalyzerServicer):
 
 def serve():
     server = grpc.server(thread_pool=ThreadPoolExecutor(max_workers=10))
-    add_analyzer_to_server(Analyzer(), server)
+    pb.add_analyzer_to_server(Analyzer(), server)
     server.add_insecure_port("0.0.0.0:{}".format(port_to_listen))
     server.start()
 

--- a/python/lookout/sdk/__init__.py
+++ b/python/lookout/sdk/__init__.py
@@ -1,3 +1,0 @@
-# re-export using pythonic names
-from lookout.sdk.service_analyzer_pb2_grpc import \
-    AnalyzerServicer, add_AnalyzerServicer_to_server as add_analyzer_to_server

--- a/python/lookout/sdk/pb.py
+++ b/python/lookout/sdk/pb.py
@@ -7,7 +7,6 @@ from .service_analyzer_pb2_grpc import \
 
 from .event_pb2_grpc import *
 from .event_pb2 import *
-from .grpc import *
 from .service_analyzer_pb2_grpc import *
 from .service_analyzer_pb2 import *
 from .service_data_pb2_grpc import *

--- a/python/lookout/sdk/pb.py
+++ b/python/lookout/sdk/pb.py
@@ -3,7 +3,7 @@ Re-exporting all grpc related classes/functions for cleaner API
 """
 
 from .service_analyzer_pb2_grpc import \
-    AnalyzerServicer, add_AnalyzerServicer_to_server as add_analyzer_to_server
+    add_AnalyzerServicer_to_server as add_analyzer_to_server
 
 from .event_pb2_grpc import *
 from .event_pb2 import *

--- a/python/lookout/sdk/pb.py
+++ b/python/lookout/sdk/pb.py
@@ -1,0 +1,14 @@
+"""
+Re-exporting all grpc related classes/functions for cleaner API
+"""
+
+from .service_analyzer_pb2_grpc import \
+    AnalyzerServicer, add_AnalyzerServicer_to_server as add_analyzer_to_server
+
+from .event_pb2_grpc import *
+from .event_pb2 import *
+from .grpc import *
+from .service_analyzer_pb2_grpc import *
+from .service_analyzer_pb2 import *
+from .service_data_pb2_grpc import *
+from .service_data_pb2 import *


### PR DESCRIPTION
Superseded #39

The first commit has the same change but correct commit message with the explanation why we need it.
The second re-export grpc stuff as we agreed in a comment to that PR.