### PR TITLE
Lock gogofaster to a fixed v1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ endif
 .PHONY: check-protoc
 check-protoc:
 		./_tools/install-protoc-maybe.sh
+.PHONY: check-gogofaster
+check-gogofaster:
+		./_tools/install-gogofaster-maybe.sh
 .PHONY: protogen
-protogen: check-protoc
-		$(GOCMD) get github.com/gogo/protobuf/protoc-gen-gogofaster
+protogen: check-protoc check-gogofaster
 		./_tools/protogen_golang.sh
 		pip3 install $(PIP_ARGS) grpcio_tools==1.13.0
 		./_tools/protogen_python.sh

--- a/_tools/install-gogofaster-maybe.sh
+++ b/_tools/install-gogofaster-maybe.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Checks protoc-gen-gogofaster installed in local 'protoc_dir' dir.
+# If it's absent installs it in 'protoc_dir' from GH release.
+
+GOGO_PROTOBUF_VER=1.2.0
+
+protoc_dir="./protoc"
+protoc_bin_dir=${protoc_dir}/bin
+
+gogo_protobuf_release_url=https://github.com/gogo/protobuf/archive/v${GOGO_PROTOBUF_VER}.zip
+gogo_protobuf_zip_path=${protoc_dir}/protobuf-${GOGO_PROTOBUF_VER}.zip
+gogo_protobuf_base_dir=${protoc_dir}/src/github.com/gogo
+gogo_protobuf_src_dir=${gogo_protobuf_base_dir}/protobuf
+gogofaster_package=${gogo_protobuf_src_dir}/protoc-gen-gogofaster
+gogofaster_bin_path=${protoc_bin_dir}/protoc-gen-gogofaster
+
+# Since 'protoc-gen-gogofaster' does not expose its version, it must be reinstalled
+if [[ -f ${gogofaster_bin_path} ]]; then
+	echo "Removing old gogofaster ${gogofaster_bin_path}"
+	rm ${gogofaster_bin_path}
+fi
+
+echo "Installing gogofaster v${GOGO_PROTOBUF_VER}"
+
+mkdir -p ${protoc_bin_dir}
+if [[ ! -f ${gogo_protobuf_zip_path} ]]; then
+	wget ${gogo_protobuf_release_url} -O ${gogo_protobuf_zip_path}
+	if [[ "$?" -ne 0 ]]; then
+		echo "Failed to download protoc release from ${gogo_protobuf_release_url}"
+		exit 2
+	fi
+fi
+
+mkdir -p ${gogo_protobuf_base_dir}
+unzip -aoq ${gogo_protobuf_zip_path} -d ${gogo_protobuf_base_dir}
+if [[ "$?" -ne 0 ]]; then
+	echo "Failed to unzip release from ${gogo_protobuf_zip_path}"
+	exit 2
+else
+	rm -rf ${gogo_protobuf_src_dir}
+	mv ${gogo_protobuf_src_dir}-${GOGO_PROTOBUF_VER} ${gogo_protobuf_src_dir}
+fi
+
+export GOPATH=`pwd`/${protoc_dir}
+go build -o ${gogofaster_bin_path} ${gogofaster_package}
+if [[ "$?" -ne 0 ]]; then
+	echo "Failed to install ${gogofaster_package} into ${gogofaster_bin_path}"
+	exit 2
+fi
+
+if ! rm -rf "${gogo_protobuf_src_dir}" ; then
+    echo "Failed to delete ${gogo_protobuf_src_dir}"
+    exit 2
+fi

--- a/_tools/install-protoc-maybe.sh
+++ b/_tools/install-protoc-maybe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Checks Protobuf compiler version.
-# If absent, installs one in protoc_dir from GH release.
+# Checks Protobuf compiler installed in local 'protoc_dir' dir.
+# If it's absent or not the expected version, installs it in 'protoc_dir' from GH release.
 
 PROTOC_VER="3.6.0"
 OS="$(uname)"

--- a/_tools/protogen_golang.sh
+++ b/_tools/protogen_golang.sh
@@ -1,20 +1,25 @@
 #!/bin/bash
 #
 # Generates Protobuf + gRCP for Golang
-# Assumes 'protoc' and 'protoc-gen-gogofaster' binaries are installed
+# Assumes 'protoc' and 'protoc-gen-gogofaster' binaries are installed in local './protoc/bin' dir
 
 PROTOC="./protoc/bin/protoc"
+GOGOFASTER="./protoc/bin/protoc-gen-gogofaster"
 sdk="lookout/sdk"
 src="proto"
 dst="golang"
 
-
 [[ -f $PROTOC ]] >/dev/null 2>&1 || { echo "Protobuf compiler is required but not found in ${PROTOC}" >&2; exit 1; }
+
+[[ -f $GOGOFASTER ]] >/dev/null 2>&1 || { echo "protoc-gen-gogofaster is required but not found in ${GOGOFASTER}" >&2; exit 1; }
 
 if ! mkdir -p "${dst}" ; then
     echo "Failed to create ${dst}"
     exit 2
 fi
+
+# 'protoc-gen-gogofaster' must be under $PATH to be found by 'protoc'
+export PATH=./protoc/bin:$PATH
 
 "${PROTOC}" -I proto \
     --gogofaster_out=plugins=grpc,\

--- a/pb/event.pb.go
+++ b/pb/event.pb.go
@@ -31,9 +31,9 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 // CommitRevision defines a range of commits, from a base to a head.
 type CommitRevision struct {
 	// Base of the revision.
-	Base ReferencePointer `protobuf:"bytes,1,opt,name=base" json:"base"`
+	Base ReferencePointer `protobuf:"bytes,1,opt,name=base,proto3" json:"base"`
 	// Head of the revision.
-	Head ReferencePointer `protobuf:"bytes,2,opt,name=head" json:"head"`
+	Head ReferencePointer `protobuf:"bytes,2,opt,name=head,proto3" json:"head"`
 }
 
 func (m *CommitRevision) Reset()         { *m = CommitRevision{} }
@@ -119,14 +119,14 @@ type PushEvent struct {
 	// InternalId is the internal id for this event at the provider.
 	InternalID string `protobuf:"bytes,2,opt,name=internal_id,json=internalId,proto3" json:"internal_id,omitempty"`
 	// CreateAt is the timestamp of the creation date of the push event.
-	CreatedAt time.Time `protobuf:"bytes,3,opt,name=created_at,json=createdAt,stdtime" json:"created_at"`
+	CreatedAt time.Time `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3,stdtime" json:"created_at"`
 	// Commits is the number of commits in the push.
 	Commits uint32 `protobuf:"varint,4,opt,name=commits,proto3" json:"commits,omitempty"`
 	// Commits is the number of distinct commits in the push.
 	DistinctCommits uint32 `protobuf:"varint,5,opt,name=distinct_commits,json=distinctCommits,proto3" json:"distinct_commits,omitempty"`
 	// Configuration contains any configuration related to specific analyzer
-	Configuration  types.Struct `protobuf:"bytes,6,opt,name=configuration" json:"configuration"`
-	CommitRevision `protobuf:"bytes,7,opt,name=commit_revision,json=commitRevision,embedded=commit_revision" json:"commit_revision"`
+	Configuration  types.Struct `protobuf:"bytes,6,opt,name=configuration,proto3" json:"configuration"`
+	CommitRevision `protobuf:"bytes,7,opt,name=commit_revision,json=commitRevision,proto3,embedded=commit_revision" json:"commit_revision"`
 }
 
 func (m *PushEvent) Reset()         { *m = PushEvent{} }
@@ -169,22 +169,22 @@ type ReviewEvent struct {
 	// InternalId is the internal id for this event at the provider.
 	InternalID string `protobuf:"bytes,2,opt,name=internal_id,json=internalId,proto3" json:"internal_id,omitempty"`
 	// CreateAt is the timestamp of the creation date of the push event.
-	CreatedAt time.Time `protobuf:"bytes,3,opt,name=created_at,json=createdAt,stdtime" json:"created_at"`
+	CreatedAt time.Time `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3,stdtime" json:"created_at"`
 	// UpdatedAt is the timestamp of the last modification of the pull request.
-	UpdatedAt time.Time `protobuf:"bytes,4,opt,name=updated_at,json=updatedAt,stdtime" json:"updated_at"`
+	UpdatedAt time.Time `protobuf:"bytes,4,opt,name=updated_at,json=updatedAt,proto3,stdtime" json:"updated_at"`
 	// IsMergeable, if the pull request is mergeable.
 	IsMergeable bool `protobuf:"varint,5,opt,name=is_mergeable,json=isMergeable,proto3" json:"is_mergeable,omitempty"`
 	// Source reference to the original branch and repository where the changes came from.
-	Source ReferencePointer `protobuf:"bytes,8,opt,name=source" json:"source"`
+	Source ReferencePointer `protobuf:"bytes,8,opt,name=source,proto3" json:"source"`
 	// Merge reference to the branch and repository where the merged Pull Request is stored.
-	Merge ReferencePointer `protobuf:"bytes,9,opt,name=merge" json:"merge"`
+	Merge ReferencePointer `protobuf:"bytes,9,opt,name=merge,proto3" json:"merge"`
 	// Configuration contains any configuration related to specific analyzer
-	Configuration types.Struct `protobuf:"bytes,10,opt,name=configuration" json:"configuration"`
+	Configuration types.Struct `protobuf:"bytes,10,opt,name=configuration,proto3" json:"configuration"`
 	// RepositoryId is internal provider repository id
 	RepositoryID uint32 `protobuf:"varint,11,opt,name=repository_id,json=repositoryId,proto3" json:"repository_id,omitempty"`
 	// Number is internal provider id of review scoped by repository
 	Number         uint32 `protobuf:"varint,12,opt,name=number,proto3" json:"number,omitempty"`
-	CommitRevision `protobuf:"bytes,7,opt,name=commit_revision,json=commitRevision,embedded=commit_revision" json:"commit_revision"`
+	CommitRevision `protobuf:"bytes,7,opt,name=commit_revision,json=commitRevision,proto3,embedded=commit_revision" json:"commit_revision"`
 }
 
 func (m *ReviewEvent) Reset()         { *m = ReviewEvent{} }

--- a/pb/service_analyzer.pb.go
+++ b/pb/service_analyzer.pb.go
@@ -28,7 +28,7 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 type EventResponse struct {
 	AnalyzerVersion string     `protobuf:"bytes,1,opt,name=analyzer_version,json=analyzerVersion,proto3" json:"analyzer_version,omitempty"`
-	Comments        []*Comment `protobuf:"bytes,2,rep,name=comments" json:"comments,omitempty"`
+	Comments        []*Comment `protobuf:"bytes,2,rep,name=comments,proto3" json:"comments,omitempty"`
 }
 
 func (m *EventResponse) Reset()         { *m = EventResponse{} }

--- a/pb/service_data.pb.go
+++ b/pb/service_data.pb.go
@@ -37,7 +37,7 @@ type File struct {
 	// Raw content of the file.
 	Content []byte `protobuf:"bytes,4,opt,name=content,proto3" json:"content,omitempty"`
 	// UAST.
-	UAST *uast.Node `protobuf:"bytes,5,opt,name=uast" json:"uast,omitempty"`
+	UAST *uast.Node `protobuf:"bytes,5,opt,name=uast,proto3" json:"uast,omitempty"`
 	// Programming/data/markup language of the file.
 	Language string `protobuf:"bytes,6,opt,name=language,proto3" json:"language,omitempty"`
 }
@@ -76,8 +76,8 @@ func (m *File) XXX_DiscardUnknown() {
 var xxx_messageInfo_File proto.InternalMessageInfo
 
 type Change struct {
-	Base *File `protobuf:"bytes,1,opt,name=base" json:"base,omitempty"`
-	Head *File `protobuf:"bytes,2,opt,name=head" json:"head,omitempty"`
+	Base *File `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
+	Head *File `protobuf:"bytes,2,opt,name=head,proto3" json:"head,omitempty"`
 }
 
 func (m *Change) Reset()         { *m = Change{} }
@@ -114,15 +114,15 @@ func (m *Change) XXX_DiscardUnknown() {
 var xxx_messageInfo_Change proto.InternalMessageInfo
 
 type ChangesRequest struct {
-	Base             *ReferencePointer `protobuf:"bytes,1,opt,name=base" json:"base,omitempty"`
-	Head             *ReferencePointer `protobuf:"bytes,2,opt,name=head" json:"head,omitempty"`
+	Base             *ReferencePointer `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
+	Head             *ReferencePointer `protobuf:"bytes,2,opt,name=head,proto3" json:"head,omitempty"`
 	IncludePattern   string            `protobuf:"bytes,3,opt,name=include_pattern,json=includePattern,proto3" json:"include_pattern,omitempty"`
 	ExcludePattern   string            `protobuf:"bytes,4,opt,name=exclude_pattern,json=excludePattern,proto3" json:"exclude_pattern,omitempty"`
 	ExcludeVendored  bool              `protobuf:"varint,5,opt,name=exclude_vendored,json=excludeVendored,proto3" json:"exclude_vendored,omitempty"`
 	WantContents     bool              `protobuf:"varint,6,opt,name=want_contents,json=wantContents,proto3" json:"want_contents,omitempty"`
 	WantUAST         bool              `protobuf:"varint,7,opt,name=want_uast,json=wantUast,proto3" json:"want_uast,omitempty"`
 	WantLanguage     bool              `protobuf:"varint,8,opt,name=want_language,json=wantLanguage,proto3" json:"want_language,omitempty"`
-	IncludeLanguages []string          `protobuf:"bytes,9,rep,name=include_languages,json=includeLanguages" json:"include_languages,omitempty"`
+	IncludeLanguages []string          `protobuf:"bytes,9,rep,name=include_languages,json=includeLanguages,proto3" json:"include_languages,omitempty"`
 }
 
 func (m *ChangesRequest) Reset()         { *m = ChangesRequest{} }
@@ -159,7 +159,7 @@ func (m *ChangesRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_ChangesRequest proto.InternalMessageInfo
 
 type FilesRequest struct {
-	Revision        *ReferencePointer `protobuf:"bytes,1,opt,name=revision" json:"revision,omitempty"`
+	Revision        *ReferencePointer `protobuf:"bytes,1,opt,name=revision,proto3" json:"revision,omitempty"`
 	IncludePattern  string            `protobuf:"bytes,2,opt,name=include_pattern,json=includePattern,proto3" json:"include_pattern,omitempty"`
 	ExcludePattern  string            `protobuf:"bytes,3,opt,name=exclude_pattern,json=excludePattern,proto3" json:"exclude_pattern,omitempty"`
 	ExcludeVendored bool              `protobuf:"varint,4,opt,name=exclude_vendored,json=excludeVendored,proto3" json:"exclude_vendored,omitempty"`
@@ -167,7 +167,7 @@ type FilesRequest struct {
 	WantUAST        bool              `protobuf:"varint,6,opt,name=want_uast,json=wantUast,proto3" json:"want_uast,omitempty"`
 	// WantLanguage set to true if UAST was requested
 	WantLanguage     bool     `protobuf:"varint,7,opt,name=want_language,json=wantLanguage,proto3" json:"want_language,omitempty"`
-	IncludeLanguages []string `protobuf:"bytes,8,rep,name=include_languages,json=includeLanguages" json:"include_languages,omitempty"`
+	IncludeLanguages []string `protobuf:"bytes,8,rep,name=include_languages,json=includeLanguages,proto3" json:"include_languages,omitempty"`
 }
 
 func (m *FilesRequest) Reset()         { *m = FilesRequest{} }


### PR DESCRIPTION
This PR would fix the issue with code generation in go, caused by a [new release](https://github.com/gogo/protobuf/releases) of `gogo/protobuf-v1.2.0`.
Because of that, Travis is failing: https://travis-ci.org/src-d/lookout-sdk/jobs/465002703
```
-	IncludeLanguages []string `protobuf:"bytes,8,rep,name=include_languages,json=includeLanguages" json:"include_languages,omitempty"`
+	IncludeLanguages []string `protobuf:"bytes,8,rep,name=include_languages,json=includeLanguages,proto3" json:"include_languages,omitempty"`
```

This PR will lock our code generation to the new `gogofaster v1.2.0`.

## Implementation
It builds `protoc-gen-gogofaster` from release `gogo/protobuf-v1.2.0` and uses it without messing user binaries nor sources.

## Caveats
- we should update `lookout` to depend on the new `protobuf v1.2.0` (it currently depends on `v1.1.1`)