### PR TITLE
Use version range for grpcio instead of exact version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -28,8 +28,8 @@ setup(
     packages=find_packages(),
     namespace_packages=["lookout"],
     keywords=["analyzer", "code-reivew"],
-    install_requires=["grpcio==1.13.0",
-                      "protobuf>=3.5.0,<4.0", "bblfsh>=2.12.0,<3.0"],
+    install_requires=["grpcio>=1.13.0,<2.0",
+                      "protobuf>=3.5.0,<4.0", "bblfsh>=2.12.7,<3.0"],
     package_data={"": ["../LICENSE.md", "../MAINTAINERS", README]},
     classifiers=[
             "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Locked version is causing error when an application needs to use newer
compatible grpcio.

Ref: https://github.com/bblfsh/client-python/pull/138

Signed-off-by: Maxim Sukharev <max@smacker.ru>