### PR TITLE
Remove outdated steps from docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ $(MAKEFILE):
 	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
-# Tools
-TOC_GENERATOR := $(CI_PATH)/gh-md-toc
-
 ifdef ($(VIRTUAL_ENV),)
 PIP_ARGS := --user
 endif

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,18 +20,6 @@ To generate the code for the gRPC services run:
 $ make protogen
 ```
 
-### Dependencies
-
-Go dependencies are managed with [dep](https://golang.github.io/dep/). Use `make godep` to make sure the `vendor` directory is up to date, and commit any necessary changes.
-
-### TOC
-
-Please update the readme Table of Contents with:
-```bash
-make toc
-```
-
-
 ## Release Process
 
  1. Make sure all the [auto-generated code](#generated-code) is up to date and committed.


### PR DESCRIPTION
I guess the `make godep` comes from copy&paste from lookout, but we don't use it here. Same for the TOC, it was removed during docs reviews.