### PR TITLE
Remove outdated warning in python init file

### DIFF
--- a/python/lookout/__init__.py
+++ b/python/lookout/__init__.py
@@ -1,4 +1,4 @@
 """Lookout - Assisted Code Review"""
-# DO NOT CHANGE OR ADD ANYTHING HERE
+
 import pkg_resources
 pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
The warning does not apply anymore, since the code is not auto-generated since #55 was merged.