### PR TITLE
Insecure connection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ For the gRPC client and server please follow these requirements:
 When DataService is being dialed, you should:
 
 - disable secure connection:
-  - go: using `grpc.WithInsecure()` ([example](https://github.com/src-d/lookout-gometalint-analyzer/blob/7b4b37fb3109299516fbb43017934d131784f49f/cmd/gometalint-analyzer/main.go#L65)).
   - python: using `server.add_insecure_port(address)` ([example](https://github.com/src-d/lookout-sdk/blob/master/examples/language-analyzer.py#L63)).
 - turn off [gRPC fail-fast](https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md) mode if your analyzer creates a connection to DataServer before it was actually started. This way the RPCs are queued until the chanel is ready:
   - go: using `grpc.FailFast(false)`

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ For the gRPC client and server please follow these requirements:
 - support [RFC 3986 URI scheme](https://github.com/grpc/grpc-go/issues/1911); lookout-sdk includes helpers for this:
   - go: using `pb.ToGoGrpcAddress` and `pb.Listen`.
   - python: using `lookout.sdk.grpc.to_grpc_address`.
+- use insecure connection:
+  - currently lookout expects to use insecure gRPC connections, as provided by `pb.DialContext`
+  - python: run server using `server.add_insecure_port(address)` ([example](https://github.com/src-d/lookout-sdk/blob/master/examples/language-analyzer.py#L63)).
 
 ## DataService
 
 When DataService is being dialed, you should:
 
-- disable secure connection:
-  - python: using `server.add_insecure_port(address)` ([example](https://github.com/src-d/lookout-sdk/blob/master/examples/language-analyzer.py#L63)).
 - turn off [gRPC fail-fast](https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md) mode if your analyzer creates a connection to DataServer before it was actually started. This way the RPCs are queued until the chanel is ready:
   - go: using `grpc.FailFast(false)`
 ([example](https://github.com/src-d/lookout-gometalint-analyzer/blob/7b4b37fb3109299516fbb43017934d131784f49f/cmd/gometalint-analyzer/main.go#L66)).

--- a/examples/language-analyzer.go
+++ b/examples/language-analyzer.go
@@ -10,7 +10,7 @@ import (
 
 	"google.golang.org/grpc"
 	"gopkg.in/bblfsh/client-go.v2/tools"
-	"gopkg.in/src-d/go-log.v1"
+	log "gopkg.in/src-d/go-log.v1"
 )
 
 // Example Analyser gRPC service implementation.
@@ -26,7 +26,7 @@ var version = "alpha"
 func (*analyzer) NotifyReviewEvent(ctx context.Context, review *pb.ReviewEvent) (*pb.EventResponse, error) {
 	log.Infof("got review request %v", review)
 
-	conn, err := pb.DialContext(ctx, dataSrvAddr, grpc.WithInsecure())
+	conn, err := pb.DialContext(ctx, dataSrvAddr)
 	if err != nil {
 		log.Errorf(err, "failed to connect to DataServer at %s", dataSrvAddr)
 		return nil, err

--- a/pb/grpc.go
+++ b/pb/grpc.go
@@ -89,6 +89,7 @@ func DialContext(ctx context.Context, target string, opts ...grpc.DialOption) (*
 			grpc.MaxCallRecvMsgSize(maxMessageSize),
 			grpc.MaxCallSendMsgSize(maxMessageSize),
 		),
+		grpc.WithInsecure(),
 	)
 
 	return grpc.DialContext(ctx, target, opts...)


### PR DESCRIPTION
Fix: #52

Python already open insecure connection by default: https://github.com/src-d/lookout-sdk/blob/master/python/lookout/sdk/grpc.py#L13

Go updated.

Doc for python `add_insecure_port` was placed in a wrong place in README (it has nothing to do with data server)