### PR TITLE
publish python sdk as sdist too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,8 @@ jobs:
         - pip3 install twine
         - cd python
       script:
-        - python3 setup.py bdist_wheel
-        - twine upload dist/*py3-none-any* -u $PYPI_LOGIN -p $PYPI_PASS
+        - python3 setup.py sdist bdist_wheel
+        - twine upload dist/*.tar.gz dist/*py3-none-any* -u $PYPI_LOGIN -p $PYPI_PASS
       skip_cleanup: true
 
 before_cache:


### PR DESCRIPTION
If you try to install lookout-sdk using pip with non-default
installation options, it will disable wheels and the installation will
fail.

Example:

```
$ pip3 install --install-option="--prefix=/install" lookout==0.3.0
/usr/local/lib/python3.6/site-packages/pip/commands/install.py:194: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.
  cmdoptions.check_install_build_global(options)
Collecting lookout==0.3.0
  Cache entry deserialization failed, entry ignored
  Could not find a version that satisfies the requirement lookout==0.3.0 (from versions: 0.0.1)
No matching distribution found for lookout==0.3.0
```

Signed-off-by: Maxim Sukharev <max@smacker.ru>