### PR TITLE
Set pyenv version 3.6.7 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
       language: go
       go: '1.10'
       env:
-        - PYENV_VERSION="3.6"
+        - PYENV_VERSION="3.6.7"
       script:
         - make protogen
         - make no-changes-in-commit


### PR DESCRIPTION
Fix #69.

Apparently `3.6` is not available in the travis image anymore, this PR sets it to `3.6.7`. Using a patch version probably means that this will break again soon, but I don't see how to fix it right now.
```
$ pyenv versions
  system
  2.7.15
* 3.6.7 (set by PYENV_VERSION environment variable)
  3.7
  3.7.1
```